### PR TITLE
Update Azure_Group_Sync.ps1 to use JSON list IPv4 an IPv6

### DIFF
--- a/Examples/GroupSync/Azure_Group_Sync.ps1
+++ b/Examples/GroupSync/Azure_Group_Sync.ps1
@@ -65,7 +65,7 @@ Microsoft's list only includes IPv4 networks.
 https://github.com/tkoopman/psCheckPoint
 
 .LINK
-https://www.microsoft.com/en-au/download/details.aspx?id=41653
+https://www.microsoft.com/en-au/download/details.aspx?id=56519
 
 #>
 [CmdletBinding(DefaultParameterSetName='Standard')]
@@ -104,22 +104,18 @@ param(
 )
 # Download code from https://gallery.technet.microsoft.com/scriptcenter/Adds-Azure-Datacenter-IP-dbeebe0c
 # Download Microsoft Azure IP Ranges and Names into Object
-$downloadUri = "https://www.microsoft.com/en-in/download/confirmation.aspx?id=41653";
+$downloadUri = "https://www.microsoft.com/en-in/download/confirmation.aspx?id=56519";
 $downloadPage = Invoke-WebRequest -Uri $downloadUri;
-$xmlFileUri = ($downloadPage.RawContent.Split('"') -like "https://*PublicIps*")[0];
-$response = Invoke-WebRequest -Uri $xmlFileUri;
-
-# Get list of regions & public IP ranges
-[xml]$xmlResponse = [System.Text.Encoding]::UTF8.GetString($response.Content);
-$regions = $xmlResponse.AzurePublicIpAddresses.Region;
-
+$jsonFileUri = ($downloadPage.RawContent.Split('"') -like "https://*.json*")[0];
+$responseDate = Invoke-WebRequest -Uri $jsonFileUri;
+$response = Invoke-RestMethod -Uri $jsonFileUri;
 if ($PrintRegions.IsPresent) {
-	$regions.Name | Sort-Object;
+	$response.values.name | Sort-Object;
 	exit;
 }
 
 # Set variables
-$Updated = [datetime]::parseexact($response.Headers.'Last-Modified',"r", [System.Globalization.CultureInfo]::InvariantCulture).ToShortDateString();
+$Updated = [datetime]::parseexact($responseDate.Headers.'Last-Modified',"r", [System.Globalization.CultureInfo]::InvariantCulture).ToShortDateString();
 $Comments = "$CommentPrefix added $Updated";
 $GroupComments = "$CommentPrefix updated $Updated";
 $Errors = 0;
@@ -132,15 +128,15 @@ if (-not $Session) {
 	exit;
 }
 
-ForEach($region in $regions) {
-	if ($region.Name -notmatch $RegionsMatch) {
+ForEach($region in $response.values) {
+	if ($region.name -notmatch $RegionsMatch) {
 		Continue;
 	}
 
-	$GroupName = $GroupPrefix + "_" + $region.Name;
+	$GroupName = $GroupPrefix + "_" + $region.name;
 	Write-Verbose "Processing $GroupName";
 
-	$region.IpRange.Subnet |
+	$region.properties.addressPrefixes | Select-String -not ':' |
 		Invoke-CheckPointGroupSync -Session $Session -GroupName $GroupName -Prefix "${HostPrefix}_" -Rename:$Rename.IsPresent -Ignore $Ignore -Color $Color -Comments $Comments -Tags $Tag -CreateGroup |
 		Tee-Object -Variable output;
 	if (($output | Where-Object {$_.Actions -ne 0 -and -not $_.Error} | Measure-Object).Count -ne 0) {


### PR DESCRIPTION
Hi!
As Microsoft doesn't maintain XML list anymore [^1], I made the changes to support the IPv4 Json lists.



[^1]

"This file will be deprecated by June 30, 2020. Please start using the JSON files listed below. IP Ranges for each cloud, broken down by region and by the tagged services in that cloud are now available on MS Download: Public: https://www.microsoft.com/en-us/download/details.aspx?id=56519 US Gov: http://www.microsoft.com/en-us/download/details.aspx?id=57063 Germany: http://www.microsoft.com/en-us/download/details.aspx?id=57064 China: http://www.microsoft.com/en-us/download/details.aspx?id=57062 These JSON files are updated weekly and include versioning both for the full file and each individual service tag in that file. The “AzureCloud” tag provides the IP ranges for that entire cloud (Public, USGov, Germany, China) and is also broken out by region within that cloud. Finally, the list of service tags in the file will be increasing as we’re constantly onboarding new azure teams to service tags."
[Link to MS](https://www.microsoft.com/en-au/download/details.aspx?id=41653)